### PR TITLE
Bumped prime-pipeline image version to 0.5.5 to reflect changes made for crossplane

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dfdsdk/prime-pipeline:0.5.4
+FROM dfdsdk/prime-pipeline:0.5.5
 
 # ========================================
 # Atlantis


### PR DESCRIPTION
Richard you will need this in infrastructure-modules.