### PR TITLE
fix: remove renovate global options

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "branchPrefix": "feature/renovate/",
-    "dryRun": null,
-    "username": "devex-sa",
-    "onboarding": false,
-    "platform": "github",
-    "repositories": [
-        "dfds/atlantis-prime-pipeline-docker"
-    ],
     "packageRules": [
         {
             "matchUpdateTypes": [


### PR DESCRIPTION
Fixes warnings:

```
 WARN: Found renovate config warnings (repository=dfds/atlantis-prime-pipeline-docker)
       "warnings": [
         {
           "topic": "Configuration Error",
           "message": "The \"dryRun\" option is a global option reserved only for Renovate's global configuration and cannot be configured within a repository's config file."
         },
         {
           "topic": "Configuration Error",
           "message": "The \"onboarding\" option is a global option reserved only for Renovate's global configuration and cannot be configured within a repository's config file."
         },
         {
           "topic": "Configuration Error",
           "message": "The \"platform\" option is a global option reserved only for Renovate's global configuration and cannot be configured within a repository's config file."
         },
         {
           "topic": "Configuration Error",
           "message": "The \"repositories\" option is a global option reserved only for Renovate's global configuration and cannot be configured within a repository's config file."
         },
         {
           "topic": "Configuration Error",
           "message": "The \"username\" option is a global option reserved only for Renovate's global configuration and cannot be configured within a repository's config file."
         }
       ]
```