### PR TITLE
Update renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,38 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "branchPrefix": "feature/renovate/",
-    "packageRules": [
-        {
-            "matchUpdateTypes": [
-                "pin",
-                "digest",
-                "patch",
-                "lockFileMaintenance"
-            ],
-            "minimumReleaseAge": "1 day",
-            "automerge": true,
-            "matchCurrentVersion": "!/^0/",
-            "ignoreTests": true,
-            "dependencyDashboardApproval": false
-        },
-        {
-            "matchUpdateTypes": [
-                "minor"
-            ],
-            "minimumReleaseAge": "7 days",
-            "automerge": true,
-            "matchCurrentVersion": "!/^0/",
-            "ignoreTests": true,
-            "dependencyDashboardApproval": false
-        },
-        {
-            "matchUpdateTypes": [
-                "major"
-            ],
-            "minimumReleaseAge": "14 days",
-            "automerge": false,
-            "dependencyDashboard": true,
-            "dependencyDashboardApproval": false
-        }
+    "extends": [
+        "local>dfds/renovate-config"
     ]
 }


### PR DESCRIPTION
This pull request simplifies the Renovate configuration by replacing custom rules with an extension of a shared configuration. The main change is to use the centralized `dfds/renovate-config` for consistency and easier maintenance.

Renovate configuration changes:

* Replaced custom `packageRules` and `branchPrefix` settings in `renovate.json` with an `extends` field that pulls configuration from `local>dfds/renovate-config`.